### PR TITLE
Update build engine and node scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,16 +8,19 @@
     "url": "https://pshry.com/"
   },
   "engines": {
-    "node": "12.x"
+    "node": "12.11.x"
   },
   "scripts": {
-    "start": "npm run build && node -r dotenv/config ./src/server/bin/www",
-    "develop": "NODE_ENV='development' npx gulp develop",
+    "start": "npm run build && npm run serve:heroku",
+    "develop": "NODE_ENV='development' gulp develop",
     "serve": "npm run serve:client & npm run serve:server",
-    "serve:client": "NODE_ENV='development' npx gulp serve",
-    "serve:server": "nodemon -r dotenv/config ./src/server/bin/www",
+    "serve:client": "NODE_ENV='development' gulp serve",
+    "serve:server": "node -r dotenv/config ./src/server/bin/www",
+    "serve:heroku": "node --optimize_for_size --max_old_space_size=460 --gc_interval=100 -r dotenv/config ./src/server/bin/www",
+    "watch": "npm run serve:client & npm run watch:server",
+    "watch:server": "nodemon -r dotenv/config ./src/server/bin/www",
     "build": "NODE_ENV='production' npx gulp",
-    "production": "NODE_ENV='production' npx gulp production"
+    "production": "NODE_ENV='production' gulp production"
   },
   "dependencies": {
     "@11ty/eleventy": "^0.10.0",


### PR DESCRIPTION
From https://devcenter.heroku.com/articles/node-best-practices#avoid-garbage

> Node (V8) uses a lazy and greedy garbage collector. With its default limit of about 1.5 GB, it sometimes waits until it absolutely has to before reclaiming unused memory. If your memory usage is increasing, it might not be a leak - but rather node’s usual lazy behavior.
> 
> To gain more control over your app’s garbage collector, you can provide flags to V8 in your Procfile:
> ```
> web: node --optimize_for_size --max_old_space_size=920 --gc_interval=100 server.js
> ```
> This is especially important if your app is running in an environment with less than 1.5 GB of available memory. For example, if you’d like to tailor node to a 512 MB container, try:
> ```
> web: node --optimize_for_size --max_old_space_size=460 --gc_interval=100 server.js
> ```